### PR TITLE
Work around Vercel serverless caching bug

### DIFF
--- a/app/api/dynamic-menu/route.ts
+++ b/app/api/dynamic-menu/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
         {
             status: 200,
             headers: {
-                "Cache-Control": "s-maxage=30",
+                "Cache-Control": "s-maxage=64800",
             },
         },
     )


### PR DESCRIPTION
Vercel automatically caches serverless function responses (https://vercel.com/docs/functions/serverless-functions/edge-caching) but overriding the default cache-control (of caching for a month) was not working well. This PR parses the URL query params which fixes this and allows cache-control (set for 18 hours) to actually work.