### PR TITLE
Add stale-while-revalidate to cache to prevent unnecessary loading times

### DIFF
--- a/app/api/dynamic-menu/route.ts
+++ b/app/api/dynamic-menu/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
         {
             status: 200,
             headers: {
-                "Cache-Control": "s-maxage=15, stale-while-revalidate",
+                "Cache-Control": "s-maxage=64800, stale-while-revalidate",
             },
         },
     )


### PR DESCRIPTION
Because it isn't very damaging to the user to see the menu items from the previous day as well, we turn stale-while-revalidate on to prevent unnecessary loading time but ensure that it will be correct for the next time they look at the site.